### PR TITLE
Wrong reStockNeeded for zones and states

### DIFF
--- a/src/state-indicators.service.js
+++ b/src/state-indicators.service.js
@@ -125,8 +125,22 @@ class StateIndicatorsService {
     }
 
     const addReStockField = (stockCount) => {
-      const groupedByStatus = productsGroupedByStatus(stockCount.stock)
-      stockCount.reStockNeeded = !!(groupedByStatus.understock.length + groupedByStatus['re-stock'].length)
+      const addAllocationIfPositive = (sum, productId) => {
+        if (stockCount.stock[productId].allocation > 0) {
+          sum = sum + stockCount.stock[productId].allocation
+        }
+        return sum
+      }
+
+      if (stockCount.location && stockCount.location.lga) {
+        const groupedByStatus = productsGroupedByStatus(stockCount.stock)
+        stockCount.reStockNeeded = !!(groupedByStatus.understock.length + groupedByStatus['re-stock'].length)
+      } else { // states and zones
+        if (stockCount.stock) {
+          const sumOfPositiveAllocations = Object.keys(stockCount.stock).reduce(addAllocationIfPositive, 0)
+          stockCount.reStockNeeded = sumOfPositiveAllocations > 0
+        }
+      }
       return stockCount
     }
 


### PR DESCRIPTION
`reStockNeeded` is true in zones and states if any of the products
is below its max threshold

Closes #26
