### PR TITLE
Remove zone dep on state allocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "angular-mocks": "^1.5.5",
     "ng-smart-id": "github:fielded/ng-smart-id#4.0.3",
     "angular-nav-data": "fielded/angular-nav-data#4.0.0",
-    "angular-nav-thresholds": "2.4.0",
+    "angular-nav-thresholds": "3.0.0",
     "babel-core": "^6.8.0",
     "ghooks": "^1.3.2",
     "babel-preset-es2015": "^6.18.0",

--- a/src/state-indicators.service.js
+++ b/src/state-indicators.service.js
@@ -21,16 +21,6 @@ const productsGroupedByStatus = (stock, products) => {
   }, { understock: [], 're-stock': [], ok: [], overstock: [] })
 }
 
-const sumAllocations = (sum, stock) => {
-  return Object.keys(stock).reduce((total, product) => {
-    total[product] = total[product] || 0
-    if (stock[product].allocation > 0) {
-      total[product] += stock[product].allocation
-    }
-    return total
-  }, sum)
-}
-
 // TODO: make sure stock_statuses is availalbe
 class StateIndicatorsService {
   constructor (
@@ -53,17 +43,6 @@ class StateIndicatorsService {
     this.locationsService = locationsService
     this.thresholdsService = thresholdsService
     this.productListService = productListService
-  }
-
-  stateRequiredAllocationsByZone (stockCounts) {
-    return stockCounts.reduce((allocations, stockCount) => {
-      if (stockCount.location && stockCount.location.state && !stockCount.location.lga && stockCount.reStockNeeded) {
-        const zone = this.smartId.idify({ zone: stockCount.location.zone }, 'locationId')
-        allocations[zone] = allocations[zone] || {}
-        allocations[zone] = sumAllocations(allocations[zone], stockCount.stock)
-      }
-      return allocations
-    }, {})
   }
 
   decorateWithIndicators (stockCounts) {


### PR DESCRIPTION
Bumps angular-nav-thresholds.
Removes zone allocation dependency on its state allocation needs.

BREAKING CHANGE: remove stateRequiredAllocationsByZone. It was
used to calculate allocations for zones, based on its state allocation
needs. This is not anymore needed with the new version of
angular-nav-thresholds.

Requires: https://github.com/fielded/angular-nav-thresholds/pull/34

Note: tests will fail until ^ is merged.

This is a breaking change, it requires removing [every call to `stateRequiredAllocationsByZone`](https://github.com/search?q=org%3Afielded+stateRequiredAllocationsByZone&type=Code) in nav-integrated-state-dashboard (new version) and nav-integrated-national-dashboard (old and only version).

It might also require changing the legends on stock allocation tables containing zones.